### PR TITLE
Fix: 페이지가 모두 로드되지 않은 상태에서 스크래핑하여 스케줄러가 중단되던 문제 수정

### DIFF
--- a/node-backend/src/domain/lck/lck.crawling.ts
+++ b/node-backend/src/domain/lck/lck.crawling.ts
@@ -53,7 +53,7 @@ export async function crawlingLckMonthSchedule(year: number, month: number) {
     broser = await puppeteer.launch()
     const page = await broser.newPage()
     page.setDefaultNavigationTimeout(0)
-    await page.goto(url)
+    await Promise.all([page.waitForNavigation({ waitUntil: 'networkidle0' }), page.goto(url)])
 
     const $ = cheerio.load(await page.content())
     const dto = $("[class*='list_wrap__']")

--- a/node-backend/src/domain/lck/lck.service.ts
+++ b/node-backend/src/domain/lck/lck.service.ts
@@ -90,7 +90,7 @@ export async function patchLckTodayMatches() {
   }
 
   try {
-    if(flag === 0) {
+    if(!flag && !currentMacthInfos.length) {
       app.locals[JobType.LckMatch].cancel()
       logger.info('LCK 매치 업데이트 스케줄러 중단')
     } 


### PR DESCRIPTION
- Promise.all()을 사용하여 waitForNavigation() 과 goto() 메소드가 모두 완료될 때까지 기다리도록 수정
- 크롤링한 데이터가 비어있다면 스케줄러를 중단하지 않도록 수정